### PR TITLE
Bug fix for receiver is empty on PurchaseRequest

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.electrum</groupId>
   <artifactId>airtime-service-test-pack</artifactId>
-  <version>1.3.0</version>
+  <version>1.3.1</version>
   <packaging>jar</packaging>
   <name>Airtime Test Pack</name>
   <description>Server and Postman scripts to test Airtime Service Interface implementations</description>

--- a/src/main/java/io/electrum/airtime/server/util/AirtimeModelUtils.java
+++ b/src/main/java/io/electrum/airtime/server/util/AirtimeModelUtils.java
@@ -85,6 +85,13 @@ public class AirtimeModelUtils {
       }
 
       Institution receiver = transaction.getReceiver();
+
+      if (receiver == null) {
+         receiver = new Institution();
+         receiver.setId("44444444");
+         receiver.setName("TransactionNetwork");
+      }
+
       thirdPartyIds.add(
             new ThirdPartyIdentifier().institutionId(settlementEntity.getId())
                   .transactionIdentifier(RandomData.random09AZ((int) ((Math.random() * 20) + 1))));


### PR DESCRIPTION
If the receiver is null on a PurchaseRequest we run into a NPE 